### PR TITLE
Rename Set Methods to avoid Conflict

### DIFF
--- a/src/main/java/org/apache/directory/fortress/core/cli/Options.java
+++ b/src/main/java/org/apache/directory/fortress/core/cli/Options.java
@@ -19,11 +19,14 @@
  */
 package org.apache.directory.fortress.core.cli;
 
+import java.util.Vector;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.directory.fortress.core.GlobalIds;
-import org.apache.directory.fortress.core.model.Group;
 import org.apache.directory.fortress.core.model.Address;
 import org.apache.directory.fortress.core.model.AdminRole;
+import org.apache.directory.fortress.core.model.Constraint;
+import org.apache.directory.fortress.core.model.Group;
 import org.apache.directory.fortress.core.model.OrgUnit;
 import org.apache.directory.fortress.core.model.PermObj;
 import org.apache.directory.fortress.core.model.Permission;
@@ -31,9 +34,6 @@ import org.apache.directory.fortress.core.model.Relationship;
 import org.apache.directory.fortress.core.model.Role;
 import org.apache.directory.fortress.core.model.SDSet;
 import org.apache.directory.fortress.core.model.User;
-import org.apache.directory.fortress.core.model.Constraint;
-
-import java.util.Vector;
 
 /**
  * This converts between Fortress entities and the JArg Options.  It contains attributes passed from JArgs command interpreter.
@@ -411,7 +411,7 @@ public class Options implements java.io.Serializable
             for (Object raw : fractionValues)
             {
                 String szRaw = (String) raw;
-                user.setRole(szRaw);
+                user.setRoleName(szRaw);
             }
         }
     }
@@ -437,7 +437,7 @@ public class Options implements java.io.Serializable
             for (Object raw : fractionValues)
             {
                 String szRaw = (String) raw;
-                user.setAdminRole(szRaw);
+                user.setAdminRoleName(szRaw);
             }
         }
     }

--- a/src/main/java/org/apache/directory/fortress/core/impl/AdminRoleDAO.java
+++ b/src/main/java/org/apache/directory/fortress/core/impl/AdminRoleDAO.java
@@ -41,13 +41,13 @@ import org.apache.directory.fortress.core.CreateException;
 import org.apache.directory.fortress.core.FinderException;
 import org.apache.directory.fortress.core.GlobalErrIds;
 import org.apache.directory.fortress.core.GlobalIds;
-import org.apache.directory.fortress.core.model.ConstraintUtil;
-import org.apache.directory.fortress.core.model.ObjectFactory;
 import org.apache.directory.fortress.core.RemoveException;
 import org.apache.directory.fortress.core.UpdateException;
 import org.apache.directory.fortress.core.ldap.ApacheDsDataProvider;
 import org.apache.directory.fortress.core.model.AdminRole;
+import org.apache.directory.fortress.core.model.ConstraintUtil;
 import org.apache.directory.fortress.core.model.Graphable;
+import org.apache.directory.fortress.core.model.ObjectFactory;
 import org.apache.directory.fortress.core.model.Role;
 import org.apache.directory.ldap.client.api.LdapConnection;
 
@@ -676,8 +676,8 @@ final class AdminRoleDAO extends ApacheDsDataProvider
         entity.setId( getAttribute( le, GlobalIds.FT_IID ) );
         entity.setDescription( getAttribute( le, SchemaConstants.DESCRIPTION_AT ) );
         entity.setOccupants( getAttributes( le, ROLE_OCCUPANT ) );
-        entity.setOsP( getAttributeSet( le, ROLE_OSP ) );
-        entity.setOsU( getAttributeSet( le, ROLE_OSU ) );
+        entity.setOsPs( getAttributeSet( le, ROLE_OSP ) );
+        entity.setOsUs( getAttributeSet( le, ROLE_OSU ) );
         entity.setName( getAttribute( le, SchemaConstants.CN_AT ) );
         unloadTemporal( le, entity );
         entity.setRoleRangeRaw( getAttribute( le, ROLE_RANGE ) );

--- a/src/main/java/org/apache/directory/fortress/core/impl/AdminRoleDAO.java
+++ b/src/main/java/org/apache/directory/fortress/core/impl/AdminRoleDAO.java
@@ -676,8 +676,8 @@ final class AdminRoleDAO extends ApacheDsDataProvider
         entity.setId( getAttribute( le, GlobalIds.FT_IID ) );
         entity.setDescription( getAttribute( le, SchemaConstants.DESCRIPTION_AT ) );
         entity.setOccupants( getAttributes( le, ROLE_OCCUPANT ) );
-        entity.setOsPs( getAttributeSet( le, ROLE_OSP ) );
-        entity.setOsUs( getAttributeSet( le, ROLE_OSU ) );
+        entity.setOsPList( getAttributeSet( le, ROLE_OSP ) );
+        entity.setOsUList( getAttributeSet( le, ROLE_OSU ) );
         entity.setName( getAttribute( le, SchemaConstants.CN_AT ) );
         unloadTemporal( le, entity );
         entity.setRoleRangeRaw( getAttribute( le, ROLE_RANGE ) );

--- a/src/main/java/org/apache/directory/fortress/core/impl/DelAdminMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/core/impl/DelAdminMgrImpl.java
@@ -146,8 +146,8 @@ public final class DelAdminMgrImpl extends Manageable implements DelAdminMgr
                 UserAdminRole chgRole = new UserAdminRole();
                 chgRole.setName(role.getName());
                 chgRole.setUserId(ue.getUserId());
-                chgRole.setOsPs(role.getOsP());
-                chgRole.setOsUs(role.getOsU());
+                chgRole.setOsPList(role.getOsP());
+                chgRole.setOsUList(role.getOsU());
                 uaRoles.remove(chgRole);
                 ConstraintUtil.copy( re, chgRole );
                 uaRoles.add(chgRole);

--- a/src/main/java/org/apache/directory/fortress/core/impl/DelAdminMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/core/impl/DelAdminMgrImpl.java
@@ -19,12 +19,15 @@
  */
 package org.apache.directory.fortress.core.impl;
 
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.directory.fortress.core.AdminMgr;
 import org.apache.directory.fortress.core.AdminMgrFactory;
 import org.apache.directory.fortress.core.DelAdminMgr;
-import org.apache.directory.fortress.core.SecurityException;
 import org.apache.directory.fortress.core.GlobalErrIds;
+import org.apache.directory.fortress.core.SecurityException;
 import org.apache.directory.fortress.core.model.AdminRole;
 import org.apache.directory.fortress.core.model.ConstraintUtil;
 import org.apache.directory.fortress.core.model.Hier;
@@ -35,9 +38,6 @@ import org.apache.directory.fortress.core.model.Relationship;
 import org.apache.directory.fortress.core.model.User;
 import org.apache.directory.fortress.core.model.UserAdminRole;
 import org.apache.directory.fortress.core.util.VUtil;
-
-import java.util.List;
-import java.util.Set;
 
 /**
  * This class implements the ARBAC02 DelAdminMgr interface for performing policy administration of Fortress ARBAC entities
@@ -146,8 +146,8 @@ public final class DelAdminMgrImpl extends Manageable implements DelAdminMgr
                 UserAdminRole chgRole = new UserAdminRole();
                 chgRole.setName(role.getName());
                 chgRole.setUserId(ue.getUserId());
-                chgRole.setOsP(role.getOsP());
-                chgRole.setOsU(role.getOsU());
+                chgRole.setOsPs(role.getOsP());
+                chgRole.setOsUs(role.getOsU());
                 uaRoles.remove(chgRole);
                 ConstraintUtil.copy( re, chgRole );
                 uaRoles.add(chgRole);

--- a/src/main/java/org/apache/directory/fortress/core/impl/UserP.java
+++ b/src/main/java/org/apache/directory/fortress/core/impl/UserP.java
@@ -27,9 +27,15 @@ import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.directory.fortress.core.GlobalErrIds;
+import org.apache.directory.fortress.core.GlobalIds;
+import org.apache.directory.fortress.core.PasswordException;
+import org.apache.directory.fortress.core.SecurityException;
+import org.apache.directory.fortress.core.ValidationException;
 import org.apache.directory.fortress.core.model.AdminRole;
 import org.apache.directory.fortress.core.model.Administrator;
 import org.apache.directory.fortress.core.model.ConstraintUtil;
+import org.apache.directory.fortress.core.model.ObjectFactory;
 import org.apache.directory.fortress.core.model.OrgUnit;
 import org.apache.directory.fortress.core.model.PwPolicy;
 import org.apache.directory.fortress.core.model.Role;
@@ -37,16 +43,9 @@ import org.apache.directory.fortress.core.model.Session;
 import org.apache.directory.fortress.core.model.User;
 import org.apache.directory.fortress.core.model.UserAdminRole;
 import org.apache.directory.fortress.core.model.UserRole;
+import org.apache.directory.fortress.core.util.VUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.directory.fortress.core.GlobalErrIds;
-import org.apache.directory.fortress.core.GlobalIds;
-import org.apache.directory.fortress.core.model.ObjectFactory;
-import org.apache.directory.fortress.core.PasswordException;
-import org.apache.directory.fortress.core.SecurityException;
-import org.apache.directory.fortress.core.ValidationException;
-import org.apache.directory.fortress.core.util.VUtil;
 
 
 /**
@@ -882,7 +881,7 @@ final class UserP
         trgR.setBeginRange(srcR.getBeginRange());
         trgR.setEndRange(srcR.getEndRange());
         // copy the user and perm pools:
-        trgR.setOsP(srcR.getOsP());
-        trgR.setOsU(srcR.getOsU());
+        trgR.setOsPs(srcR.getOsP());
+        trgR.setOsUs(srcR.getOsU());
     }
 }

--- a/src/main/java/org/apache/directory/fortress/core/impl/UserP.java
+++ b/src/main/java/org/apache/directory/fortress/core/impl/UserP.java
@@ -881,7 +881,7 @@ final class UserP
         trgR.setBeginRange(srcR.getBeginRange());
         trgR.setEndRange(srcR.getEndRange());
         // copy the user and perm pools:
-        trgR.setOsPs(srcR.getOsP());
-        trgR.setOsUs(srcR.getOsU());
+        trgR.setOsPList(srcR.getOsP());
+        trgR.setOsUList(srcR.getOsU());
     }
 }

--- a/src/main/java/org/apache/directory/fortress/core/model/AdminRole.java
+++ b/src/main/java/org/apache/directory/fortress/core/model/AdminRole.java
@@ -313,7 +313,7 @@ public class AdminRole extends Role implements Administrator
      * @param osPs is a List of type String containing Perm OU.  This maps to 'ftOSP' attribute on 'ftPools' aux object class.
      */
     @Override
-    public void setOsP( Set<String> osPs )
+    public void setOsPs( Set<String> osPs )
     {
         this.osPs = osPs;
     }
@@ -354,7 +354,7 @@ public class AdminRole extends Role implements Administrator
      * @param osUs is a List of type String containing User OU.  This maps to 'ftOSU' attribute on 'ftPools' aux object class.
      */
     @Override
-    public void setOsU( Set<String> osUs )
+    public void setOsUs( Set<String> osUs )
     {
         this.osUs = osUs;
     }

--- a/src/main/java/org/apache/directory/fortress/core/model/AdminRole.java
+++ b/src/main/java/org/apache/directory/fortress/core/model/AdminRole.java
@@ -313,7 +313,7 @@ public class AdminRole extends Role implements Administrator
      * @param osPs is a List of type String containing Perm OU.  This maps to 'ftOSP' attribute on 'ftPools' aux object class.
      */
     @Override
-    public void setOsPs( Set<String> osPs )
+    public void setOsPList( Set<String> osPs )
     {
         this.osPs = osPs;
     }
@@ -354,7 +354,7 @@ public class AdminRole extends Role implements Administrator
      * @param osUs is a List of type String containing User OU.  This maps to 'ftOSU' attribute on 'ftPools' aux object class.
      */
     @Override
-    public void setOsUs( Set<String> osUs )
+    public void setOsUList( Set<String> osUs )
     {
         this.osUs = osUs;
     }

--- a/src/main/java/org/apache/directory/fortress/core/model/Administrator.java
+++ b/src/main/java/org/apache/directory/fortress/core/model/Administrator.java
@@ -45,7 +45,7 @@ public interface Administrator
      *
      * @param osPs is a List of type String containing Perm OU.  This maps to 'ftOSP' attribute on 'ftPools' aux object class.
      */
-    void setOsP( Set<String> osPs );
+    void setOsPs( Set<String> osPs );
 
 
     /**
@@ -69,7 +69,7 @@ public interface Administrator
      *
      * @param osUs is a List of type String containing User OU.  This maps to 'ftOSU' attribute on 'ftPools' aux object class.
      */
-    void setOsU( Set<String> osUs );
+    void setOsUs( Set<String> osUs );
 
 
     /**

--- a/src/main/java/org/apache/directory/fortress/core/model/Administrator.java
+++ b/src/main/java/org/apache/directory/fortress/core/model/Administrator.java
@@ -45,7 +45,7 @@ public interface Administrator
      *
      * @param osPs is a List of type String containing Perm OU.  This maps to 'ftOSP' attribute on 'ftPools' aux object class.
      */
-    void setOsPs( Set<String> osPs );
+    void setOsPList( Set<String> osPs );
 
 
     /**
@@ -69,7 +69,7 @@ public interface Administrator
      *
      * @param osUs is a List of type String containing User OU.  This maps to 'ftOSU' attribute on 'ftPools' aux object class.
      */
-    void setOsUs( Set<String> osUs );
+    void setOsUList( Set<String> osUs );
 
 
     /**

--- a/src/main/java/org/apache/directory/fortress/core/model/User.java
+++ b/src/main/java/org/apache/directory/fortress/core/model/User.java
@@ -690,7 +690,7 @@ public class User extends FortEntity implements Constraint, Serializable
      *
      * @param roleName contains role name to target for activation into {@link org.apache.directory.fortress.core.model.Session}.
      */
-    public void setRole( String roleName )
+    public void setRoleName( String roleName )
     {
         if ( roles == null )
         {
@@ -764,7 +764,7 @@ public class User extends FortEntity implements Constraint, Serializable
      *
      * @param roleName contrains adminRole name.
      */
-    public void setAdminRole( String roleName )
+    public void setAdminRoleName( String roleName )
     {
         if ( adminRoles == null )
         {

--- a/src/main/java/org/apache/directory/fortress/core/model/UserAdminRole.java
+++ b/src/main/java/org/apache/directory/fortress/core/model/UserAdminRole.java
@@ -425,7 +425,7 @@ public class UserAdminRole extends UserRole implements Administrator
      * @param osPs is a List of type String containing Perm OU.  This maps to 'ftARC' attribute on 'ftUserAttrs' aux object class.
      */
     @Override
-    public void setOsPs( Set<String> osPs )
+    public void setOsPList( Set<String> osPs )
     {
         this.osPs = osPs;
     }
@@ -466,7 +466,7 @@ public class UserAdminRole extends UserRole implements Administrator
      * @param osUs is a List of type String containing User OU.  This maps to 'ftARC' attribute on 'ftUserAttrs' aux object class.
      */
     @Override
-    public void setOsUs( Set<String> osUs )
+    public void setOsUList( Set<String> osUs )
     {
         this.osUs = osUs;
     }

--- a/src/main/java/org/apache/directory/fortress/core/model/UserAdminRole.java
+++ b/src/main/java/org/apache/directory/fortress/core/model/UserAdminRole.java
@@ -425,7 +425,7 @@ public class UserAdminRole extends UserRole implements Administrator
      * @param osPs is a List of type String containing Perm OU.  This maps to 'ftARC' attribute on 'ftUserAttrs' aux object class.
      */
     @Override
-    public void setOsP( Set<String> osPs )
+    public void setOsPs( Set<String> osPs )
     {
         this.osPs = osPs;
     }
@@ -466,7 +466,7 @@ public class UserAdminRole extends UserRole implements Administrator
      * @param osUs is a List of type String containing User OU.  This maps to 'ftARC' attribute on 'ftUserAttrs' aux object class.
      */
     @Override
-    public void setOsU( Set<String> osUs )
+    public void setOsUs( Set<String> osUs )
     {
         this.osUs = osUs;
     }

--- a/src/test/java/org/apache/directory/fortress/core/impl/AdminRoleTestData.java
+++ b/src/test/java/org/apache/directory/fortress/core/impl/AdminRoleTestData.java
@@ -980,8 +980,8 @@ public class AdminRoleTestData extends TestCase
         AdminRole role = ( AdminRole ) getRoleConstraint( rle );
         role.setName( RoleTestData.getName( rle ) );
         role.setDescription( RoleTestData.getDescription( rle ) );
-        role.setOsU( getOsU( rle ) );
-        role.setOsP( getOsP( rle ) );
+        role.setOsUList( getOsU( rle ) );
+        role.setOsPList( getOsP( rle ) );
         role.setBeginRange( getBeginRange( rle ) );
         role.setEndRange( getEndRange( rle ) );
         role.setBeginInclusive( isBeginInclusive( rle ) );

--- a/src/test/java/org/apache/directory/fortress/core/impl/accelerator/TestAccelerator.java
+++ b/src/test/java/org/apache/directory/fortress/core/impl/accelerator/TestAccelerator.java
@@ -19,21 +19,24 @@
  */
 package org.apache.directory.fortress.core.impl.accelerator;
 
-import org.apache.directory.fortress.core.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.directory.fortress.core.AccelMgr;
+import org.apache.directory.fortress.core.AccelMgrFactory;
 import org.apache.directory.fortress.core.SecurityException;
+import org.apache.directory.fortress.core.impl.TestUtils;
+import org.apache.directory.fortress.core.model.Permission;
+import org.apache.directory.fortress.core.model.Session;
+import org.apache.directory.fortress.core.model.User;
+import org.apache.directory.fortress.core.model.UserRole;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.directory.fortress.core.AccelMgr;
-import org.apache.directory.fortress.core.model.Permission;
-import org.apache.directory.fortress.core.model.Session;
-import org.apache.directory.fortress.core.impl.TestUtils;
-import org.apache.directory.fortress.core.model.User;
-import org.apache.directory.fortress.core.model.UserRole;
-
-import static org.junit.Assert.*;
 
 public class TestAccelerator
 {
@@ -83,8 +86,8 @@ public class TestAccelerator
             // positive test case:
             user.setUserId( "rbacuser1" );
             user.setPassword( "secret".toCharArray() );
-            user.setRole( "rbacrole1" );
-            user.setRole( "rbacrole2" );
+            user.setRoleName( "rbacrole1" );
+            user.setRoleName( "rbacrole2" );
             session = accelMgr.createSession( user, false );
             assertNotNull( session );
             assertTrue( session.isAuthenticated() );
@@ -188,7 +191,7 @@ public class TestAccelerator
             // positive test case:
             user.setUserId( "rbacuser1" );
             user.setPassword( "secret".toCharArray() );
-            user.setRole( "rbacrole1" );
+            user.setRoleName( "rbacrole1" );
             //user.setRole( "rbacrole2" );
             session = accelMgr.createSession( user, false );
             assertNotNull( session );

--- a/src/test/java/org/apache/directory/fortress/core/samples/CreateSessionSample.java
+++ b/src/test/java/org/apache/directory/fortress/core/samples/CreateSessionSample.java
@@ -19,22 +19,23 @@
  */
 package org.apache.directory.fortress.core.samples;
 
-import org.apache.directory.fortress.core.AccessMgr;
-import org.apache.directory.fortress.core.AccessMgrFactory;
-import org.apache.directory.fortress.core.PasswordException;
-import org.apache.directory.fortress.core.SecurityException;
-import org.apache.directory.fortress.core.GlobalErrIds;
-import org.apache.directory.fortress.core.impl.TestUtils;
-import org.apache.directory.fortress.core.model.User;
-import org.apache.directory.fortress.core.model.Session;
-import org.apache.directory.fortress.core.model.UserRole;
+import java.util.List;
+
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+
+import org.apache.directory.fortress.core.AccessMgr;
+import org.apache.directory.fortress.core.AccessMgrFactory;
+import org.apache.directory.fortress.core.GlobalErrIds;
+import org.apache.directory.fortress.core.PasswordException;
+import org.apache.directory.fortress.core.SecurityException;
+import org.apache.directory.fortress.core.impl.TestUtils;
+import org.apache.directory.fortress.core.model.Session;
+import org.apache.directory.fortress.core.model.User;
+import org.apache.directory.fortress.core.model.UserRole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 /**
  * CreateSessionSample JUnit Test. Fortress Sessions are modeled on the RBAC specification.  Each Session
@@ -230,7 +231,7 @@ public class CreateSessionSample extends TestCase
             for (String roleName : roles)
             {
                 // Add the Role name to list of Roles to be activated on Session.
-                user.setRole(roleName);
+                user.setRoleName(roleName);
             }
 
             // The API will verify User is good and perform Role activations.  Request will fail if User is locked out of ldap for any reason.


### PR DESCRIPTION
I renamed the duplicate set methods. My junit tests don't work even before I made the change, so not sure how to propertly test. This is the error I get when running "mvn test -Dtest=FortressJUnitTest"

Tests run: 141, Failures: 5, Errors: 0, Skipped: 0, Time elapsed: 228.481 sec <<< FAILURE! - in org.apache.directory.fortress.core.impl.FortressJUnitTest
testSearchBinds(org.apache.directory.fortress.core.impl.AuditMgrImplTest)  Time elapsed: 0.022 sec  <<< FAILURE!
junit.framework.AssertionFailedError: org.apache.directory.fortress.core.impl.AuditMgrImplTestsearchBinds failed search for successful authentication user [jtsUser1]
    at junit.framework.Assert.fail(Assert.java:57)
    at junit.framework.Assert.assertTrue(Assert.java:22)
    at junit.framework.TestCase.assertTrue(TestCase.java:192)
    at org.apache.directory.fortress.core.impl.AuditMgrImplTest.searchBinds(AuditMgrImplTest.java:426)
    at org.apache.directory.fortress.core.impl.AuditMgrImplTest.testSearchBinds(AuditMgrImplTest.java:399)
