### PR TITLE
Concern about Connection Pooling and String concatenation

### DIFF
--- a/src/main/java/org/apache/directory/fortress/core/rest/RestUtils.java
+++ b/src/main/java/org/apache/directory/fortress/core/rest/RestUtils.java
@@ -230,7 +230,7 @@ public final class RestUtils
         LOG.debug( "get function1:{}, id1:{}, id2:{}, id3:{}, url:{}", function, id, id2, id3, url );
         HttpGet get = new HttpGet(url);
         setMethodHeaders( get );
-        return handleHttpMethod( get ,HttpClientBuilder.create()
+        return handleHttpMethod( get ,HttpClientBuilder.create().useSystemProperties()
             .setDefaultCredentialsProvider(getCredentialProvider(userId, password)).build() );
     }
 
@@ -272,7 +272,7 @@ public final class RestUtils
         {
             HttpEntity entity = new StringEntity( szInput, ContentType.TEXT_XML );
             post.setEntity( entity );
-            org.apache.http.client.HttpClient httpclient = HttpClientBuilder.create()
+            org.apache.http.client.HttpClient httpclient = HttpClientBuilder.create().useSystemProperties()
                 .setDefaultCredentialsProvider(getCredentialProvider(userId, password)).build();
             HttpResponse response = httpclient.execute( post );
             String error;


### PR DESCRIPTION
I think i was missed about the performance mode for RestUtils class. it use only the default max connection which only 2 if we did not specified any max connection for connection pooling.

With the changed i made, we able to use http.maxConnections property at runtime to specified how many maximum connection that we want to have.

Apart from the connection pool, i think we could use StringUtils from apache common lang3 to reduce the memory footprint of string concatenation too.

from some code like this : 

String error = "safeText value [" + value + "] invalid length [" + length + "]";

into something like this : 

StringUtils.join(new String[] {"safeText value [", value, "] invalid length [", String.valueOf(length), "]"}, null)

Please advise, if you agree then i will refactor the existing String concatenation at this project (Since i only change the pooling when submit this request) within the same pull request.