### PR TITLE
fix load ldap properties bug

### DIFF
--- a/src/main/java/org/apache/directory/fortress/core/ldap/LdapDataProvider.java
+++ b/src/main/java/org/apache/directory/fortress/core/ldap/LdapDataProvider.java
@@ -1147,10 +1147,7 @@ public abstract class LdapDataProvider
                 {
                     attr = new DefaultAttribute( attrName );
                 }
-                else
-                {
-                    attr.add( prop );
-                }
+                attr.add( prop );
             }
 
             if ( attr != null )


### PR DESCRIPTION
Here after new DefaultAttribute, the first prop is not added to the attribute.